### PR TITLE
Add stubs

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,6 +1,6 @@
 parameters:
-    stubFiles:
-        - stubs/Livewire/Features/SupportEvents/HandlesEvents.stub
+  stubFiles:
+    - stubs/Livewire/Features/SupportEvents/HandlesEvents.stub
 services:
   - class: CalebDW\LarastanLivewire\Properties\ComputedPropertyExtension
     tags: [phpstan.broker.propertiesClassReflectionExtension]

--- a/extension.neon
+++ b/extension.neon
@@ -1,3 +1,6 @@
+parameters:
+    stubFiles:
+        - stubs/Livewire/Features/SupportEvents/HandlesEvents.stub
 services:
   - class: CalebDW\LarastanLivewire\Properties\ComputedPropertyExtension
     tags: [phpstan.broker.propertiesClassReflectionExtension]

--- a/stubs/Livewire/Features/SupportEvents/HandlesEvents.stub
+++ b/stubs/Livewire/Features/SupportEvents/HandlesEvents.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace Livewire\Features\SupportEvents;
+
+use function Livewire\store;
+
+trait HandlesEvents
+{
+    /** @var array<string> */
+    protected $listeners = [];
+
+    /**
+     * @return array<string>
+     */
+    protected function getListeners() {}
+
+    /**
+     * @param string $event
+     * @param mixed... $params
+     *
+     * @return Event
+     */
+    public function dispatch($event, ...$params) {}
+}

--- a/stubs/Livewire/Features/SupportEvents/HandlesEvents.stub
+++ b/stubs/Livewire/Features/SupportEvents/HandlesEvents.stub
@@ -12,7 +12,7 @@ trait HandlesEvents
     /**
      * @return array<string>
      */
-    protected function getListeners() {}
+    protected function getListeners();
 
     /**
      * @param string $event
@@ -20,5 +20,5 @@ trait HandlesEvents
      *
      * @return Event
      */
-    public function dispatch($event, ...$params) {}
+    public function dispatch($event, ...$params);
 }


### PR DESCRIPTION
This adds a stub for `HandlesEvents` so that `Componet::$listeners` isn't mixed. If you work on a project that both require that array elements are typed, does not allow type violation or redundant types then Livewire is a bit of a pain to work with since almost everything is `mixed`. I was able to workaround it in all other cases but this one required a stub.

I have of cause also tried to update the code upstream but they are very slow / reluctant to accept PRs with type documentation: https://github.com/livewire/livewire/pulls/AJenbo